### PR TITLE
Add Tooltip Version Clarification

### DIFF
--- a/wp-content/themes/cpnet-developer/functions.php
+++ b/wp-content/themes/cpnet-developer/functions.php
@@ -300,7 +300,7 @@ function header_js() {
 
 function theme_scripts_styles() {
 	wp_enqueue_style( 'dashicons' );
-	wp_enqueue_style( 'cpnet-developer-style', get_stylesheet_uri(), array(), '20210723.3' );
+	wp_enqueue_style( 'cpnet-developer-style', get_stylesheet_uri(), array(), '20211122' );
 	wp_enqueue_style( 'wp-dev-sass-compiled', get_template_directory_uri() . '/stylesheets/main.css', array( 'cpnet-developer-style' ), '20210716' );
 	wp_enqueue_script( 'wporg-developer-skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array(), '20130115', true );
 	wp_enqueue_script( 'wporg-developer-search', get_template_directory_uri() . '/js/search.js', array(), '20150430', true );

--- a/wp-content/themes/cpnet-developer/reference/template-changelog.php
+++ b/wp-content/themes/cpnet-developer/reference/template-changelog.php
@@ -19,7 +19,13 @@ if ( ! empty( $changelog_data ) ) :
 			<caption class="screen-reader-text"><?php _e( 'Changelog', 'wporg' ); ?></caption>
 			<thead>
 				<tr>
-					<th class="changelog-version"><?php _e( 'Version', 'wporg' ); ?></th>
+					<th class="changelog-version"><?php _e( 'Version', 'wporg' ); ?><span class="btn btn-primary tooltip"><span>?</span>
+	    				<div class="right">
+	        				<span><?php _e( 'Versions with <code>WP-</code> prefix describe changes made in WordPress prior to ClassicPress fork.', 'wporg' ); ?></span>
+	        				<i></i>
+						</div>
+					</span>
+					</th>
 					<th class="changelog-desc"><?php _e( 'Description', 'wporg' ); ?></th>
 				</tr>
 			</thead>

--- a/wp-content/themes/cpnet-developer/style.css
+++ b/wp-content/themes/cpnet-developer/style.css
@@ -151,3 +151,56 @@ a.cp-heading-link:hover {
 .cpnet-toc {
 	margin-bottom: 1.5em;
 }
+
+/* ToolTip for CP/WP Version clarification */
+.tooltip {
+    margin-left: 5px;
+    position:relative;
+    border-bottom:1px dotted #666;
+    text-align:left;
+}
+
+.tooltip .right {
+    min-width:200px; 
+    top:50%;
+    left:100%;
+    margin-left:20px;
+    transform:translate(0, -50%);
+    padding:10px 20px;
+    color:#000000;
+    background-color:#EEEEEE;
+    font-weight:normal;
+    font-size:13px;
+    border-radius:8px;
+    position:absolute;
+    z-index:99999999;
+    box-sizing:border-box;
+    box-shadow:0 1px 8px rgba(0,0,0,0.5);
+    visibility:hidden; opacity:0; transition:opacity 0.8s;
+}
+
+.tooltip:hover .right, .tooltip:focus .right {
+    visibility:visible; opacity:1;
+}
+
+.tooltip .right i {
+    position:absolute;
+    top:50%;
+    right:100%;
+    margin-top:-12px;
+    width:12px;
+    height:24px;
+    overflow:hidden;
+}
+
+.tooltip .right i::after {
+    content:'';
+    position:absolute;
+    width:12px;
+    height:12px;
+    left:0;
+    top:50%;
+    transform:translate(50%,-50%) rotate(-45deg);
+    background-color:#EEEEEE;
+    box-shadow:0 1px 8px rgba(0,0,0,0.5);
+}


### PR DESCRIPTION
Adds HTML required for ToolTip to explain version
<img width="1018" alt="Screenshot 2021-11-22 at 18 36 02" src="https://user-images.githubusercontent.com/11800236/142854943-93d286b3-c2b2-4aa4-9dd5-f0ac2fab1b82.png">
 